### PR TITLE
docs: polish README with logo header and zero-config quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,112 @@
-# OpenClaw Redact Plugin
+<div align="center">
 
-OpenClaw plugin that delegates PII detection to the Rust-powered
-[censgate/redact](https://github.com/censgate/redact) **HTTP API**.
+<img src="https://raw.githubusercontent.com/censgate/redact/main/assets/censgate-redact-logo-v1.png" alt="Censgate Redact" width="400">
 
-This package does **not** implement local regex-based detection logic. It wraps
-the upstream Redact engine and applies redaction/restoration behavior in OpenClaw hooks.
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.14-339933?logo=node.js)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![CI](https://github.com/censgate/openclaw-redact/actions/workflows/ci.yml/badge.svg)](https://github.com/censgate/openclaw-redact/actions)
+[![npm](https://img.shields.io/npm/v/@censgate/openclaw-redact.svg)](https://www.npmjs.com/package/@censgate/openclaw-redact)
 
-## Backend choice
+**PII redaction for OpenClaw, powered by [Censgate Redact](https://github.com/censgate/redact)**
 
-- Backend: **HTTP only**
-- Expected engine: `redact-api` from `censgate/redact`
-- Recommended image (ONNX NER enabled): `ghcr.io/censgate/redact:full`
+OpenClaw plugin that calls the Rust **Redact HTTP API** on the LLM path and restores reversible placeholders after the model runs.
+
+[Quick start](#quick-start) · [Documentation](#documentation) · [How it works](#how-it-works) · [Configuration](#configuration) · [Contributing](CONTRIBUTING.md)
+
+</div>
+
+---
+
+## Features
+
+- **Engine-backed** — Detection and policy live in [censgate/redact](https://github.com/censgate/redact) (`redact-api`), not duplicated in TypeScript
+- **HTTP only** — No bundled regex/ML; you point the plugin at a Redact API (local or remote)
+- **Sensible defaults** — Reversible redaction, Docker-backed Redact auto-start with `ghcr.io/censgate/redact:full`, dynamic host port by default
+- **Self-healing** — If the API is down at first use, the plugin can start or reuse a container, discover the mapped port, and retry
+- **OpenClaw-native** — `preLLMHook` / `postLLMHook` integration with per-turn token storage for restore
+
+This package does **not** implement local pattern matching. It wraps the upstream engine and applies redaction/restoration in OpenClaw hooks.
+
+## Requirements
+
+- **Node.js** [>= 22.14.0](https://nodejs.org/) (see `engines` in `package.json`)
+- **OpenClaw** with plugin support, compatible with this package’s OpenClaw peer range
+- **Docker** (recommended for the default “zero config” path) to auto-run the [Redact full image](https://github.com/censgate/redact) (`ghcr.io/censgate/redact:full`) with ONNX-capable NER
+- **Alternative:** run Redact yourself (e.g. `docker run` or a hosted `redact-api`) and set `REDACT_API_ENDPOINT` or `http.endpoint` if not using the default
 
 ## Quick start
 
-Run Redact API with ONNX capabilities enabled:
-
-```bash
-docker run --rm -p 8080:8080 ghcr.io/censgate/redact:full
-```
-
-Install plugin:
+**1. Install the plugin**
 
 ```bash
 openclaw plugins install @censgate/openclaw-redact
 ```
 
-Configure in `openclaw.json`:
+**2. Use defaults — no `openclaw.json` block required** for a typical local setup.
+
+By default the plugin is enabled, uses **reversible** redaction, and (with Docker available) will **auto-start** the Redact API container `ghcr.io/censgate/redact:full`, map a **free host port**, and call that endpoint. The default logical endpoint is `http://127.0.0.1:8080` until a dynamic port is resolved after bootstrap.
+
+**3. Optional — if you use a plugin allowlist**, allow the plugin id and ensure it is enabled:
 
 ```json
 {
   "plugins": {
+    "allow": ["censgate-redact"],
     "entries": {
-      "censgate-redact": {
-        "enabled": true,
-        "config": {
-          "mode": "reversible",
-          "excludeAgents": ["internal-trusted"],
-          "logRedactions": false,
-          "http": {
-            "endpoint": "http://127.0.0.1:8080",
-            "timeoutMs": 1500,
-            "language": "en",
-            "docker": {
-              "enabled": true,
-              "image": "ghcr.io/censgate/redact:full",
-              "containerName": "openclaw-redact-api",
-              "host": "127.0.0.1",
-              "containerPort": 8080,
-              "restartOnFailure": true
-            }
-          }
-        }
-      }
+      "censgate-redact": { "enabled": true }
     }
   }
 }
 ```
 
-When `http.docker.enabled` is `true`, the plugin will:
-- attempt Redact API call normally first
-- if unreachable, auto-start/reuse the Docker container
-- detect the mapped host port (including dynamic/random port assignment)
-- update the runtime endpoint and retry automatically
-- if the backend later becomes unreachable while OpenClaw is running, it retries
-  bootstrap and (optionally) restarts the running container
+**Manual Redact (no auto-start):** if you do not use Docker, start the API yourself, then align the endpoint:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/censgate/redact:full
+# Plugin defaults expect http://127.0.0.1:8080 (or set REDACT_API_ENDPOINT).
+```
+
+## Installation
+
+- **From npm (recommended for users):** `openclaw plugins install @censgate/openclaw-redact` (or `npm install -g` / `npx` patterns your OpenClaw version documents).
+- **From source (contributors):** clone this repo, run `npm install`, `npm run build`, then point OpenClaw at the built extension per OpenClaw’s local-plugin instructions.
+
+Package id in OpenClaw: **`censgate-redact`** (see `openclaw.plugin.json`).
+
+## Backend
+
+- **Protocol:** HTTP only to Redact’s REST API
+- **Engine:** `redact-api` from [censgate/redact](https://github.com/censgate/redact)
+- **Recommended image (pattern + ONNX NER):** `ghcr.io/censgate/redact:full` — used by the plugin’s default Docker auto-start
 
 ## How it works
 
 1. `preLLMHook` calls `POST /api/v1/analyze` on the Redact API.
-2. Detected spans are replaced with `[REDACTED:<ENTITY_TYPE>:<id>]` placeholders
-   in reversible mode (or non-reversible placeholders in irreversible mode).
+2. Detected spans are replaced with `[REDACTED:<ENTITY_TYPE>:<id>]` placeholders in **reversible** mode (or non-reversible placeholders in **irreversible** mode).
 3. `postLLMHook` restores reversible placeholders using per-turn token storage.
 
-## Environment variables
+## Configuration
 
-- `REDACT_API_ENDPOINT` (default: `http://127.0.0.1:8080`)
-- `REDACT_DOCKER_AUTOSTART` (`true|false`, default `true`)
-- `REDACT_DOCKER_IMAGE` (default `ghcr.io/censgate/redact:full`)
-- `REDACT_DOCKER_CONTAINER_NAME` (default `openclaw-redact-api`)
-- `REDACT_DOCKER_HOST` (default `127.0.0.1`)
-- `REDACT_DOCKER_HOST_PORT` (optional; if omitted, Docker chooses a free port)
-- `REDACT_DOCKER_CONTAINER_PORT` (default `8080`)
-- `REDACT_DOCKER_PULL` (`true|false`, default `false`)
-- `REDACT_DOCKER_RESTART_ON_FAILURE` (`true|false`, default `true`)
-- `REDACT_DOCKER_STARTUP_TIMEOUT_MS` (default `30000`)
-- `REDACT_DOCKER_STARTUP_PROBE_INTERVAL_MS` (default `500`)
+### Default behavior (out of the box)
 
-## Default posture (out-of-the-box)
+With no custom config, the plugin typically:
 
-Without any custom config, the plugin defaults to:
-- Docker-backed Redact auto-start enabled
-- ONNX-capable image: `ghcr.io/censgate/redact:full`
-- Dynamic host port assignment (avoids collisions)
-- Runtime self-healing + restart-on-failure
-- Reversible redaction mode
-- No `entityTypes` filter (lets Redact apply its full built-in recognizer set for broad PII/HIPAA/GDPR-oriented coverage)
+- Stays **enabled**; **reversible** mode; no agent exclude list; redaction logging off
+- Uses **Docker-backed Redact auto-start** (unless disabled via env or config)
+- Pulls the **full** image by default: `ghcr.io/censgate/redact:full`
+- Assigns a **dynamic host port** when `hostPort` is unset (avoids collisions)
+- **Retries** and may **restart** the container on failure, per `resolveConfig` / Docker bootstrap behavior
+- Leaves **`entityTypes` unset** so Redact applies its full built-in recognizer set (broad PII / HIPAA / GDPR–oriented coverage)
 
-## Production profile (high-throughput)
+### When Docker auto-start is on
 
-For sustained production load, pin a stable host port, increase request timeout,
-and proactively pull the image at startup to reduce first-failure recovery latency.
+- The plugin attempts a Redact API call first.
+- If unreachable, it auto-starts or reuses the container, detects the mapped host port (including dynamic assignment), updates the runtime endpoint, and retries.
+- If the backend becomes unreachable while OpenClaw is running, it can retry bootstrap and optionally restart the container.
+
+### Advanced / production (optional)
+
+For sustained load, pin a stable host port, raise timeouts, and optionally pre-pull the image. Example:
 
 ```json
 {
@@ -136,11 +142,24 @@ and proactively pull the image at startup to reduce first-failure recovery laten
 }
 ```
 
-Recommended notes:
-- Keep `entityTypes` unset unless you intentionally need to reduce scope.
-- Use `mode: "irreversible"` for strictly untrusted downstream workflows.
-- If running multiple OpenClaw instances on one host, give each a unique
-  `containerName` and `hostPort`.
+**Notes:** Keep `entityTypes` unset unless you need a narrower scope. Use `mode: "irreversible"` for strictly untrusted downstream workflows. For multiple OpenClaw instances on one host, use unique `containerName` and `hostPort` values.
+
+## Environment variables
+
+| Variable | Role |
+|----------|------|
+| `REDACT_API_ENDPOINT` | Redact base URL (default: `http://127.0.0.1:8080`) |
+| `REDACT_ENTITY_TYPES` | Comma-separated entity filter (optional) |
+| `REDACT_DOCKER_AUTOSTART` | `true\|false` (default: `true`) |
+| `REDACT_DOCKER_IMAGE` | Default: `ghcr.io/censgate/redact:full` |
+| `REDACT_DOCKER_CONTAINER_NAME` | Default: `openclaw-redact-api` |
+| `REDACT_DOCKER_HOST` | Default: `127.0.0.1` |
+| `REDACT_DOCKER_HOST_PORT` | Optional; omit for dynamic port |
+| `REDACT_DOCKER_CONTAINER_PORT` | Default: `8080` |
+| `REDACT_DOCKER_PULL` | `true\|false` (default: `false`) |
+| `REDACT_DOCKER_RESTART_ON_FAILURE` | `true\|false` (default: `true`) |
+| `REDACT_DOCKER_STARTUP_TIMEOUT_MS` | Default: `30000` |
+| `REDACT_DOCKER_STARTUP_PROBE_INTERVAL_MS` | Default: `500` |
 
 ## Development
 
@@ -150,55 +169,63 @@ npm run build
 npm test
 ```
 
-Remove build output, npm pack tarballs, and verification artifacts: `make clean` (or `npm run clean`).
+Clean build artifacts, pack tarballs, and verification output: `make clean` (or `npm run clean`).
 
-## Verification suite (ENG-56)
+## Testing & verification
 
-**Tier 1** — fast hook harness against a Dockerized **censgate/redact** API (no external LLM services):
+**Tier 1** — fast hook harness against a Dockerized **censgate/redact** API (no external LLM):
 
 ```bash
 make verify
 ```
 
-Produces `verification-report.json` (gitignored) and uses Vitest configs in `vitest.verification.config.ts`.
+Produces `verification-report.json` (gitignored); config in `vitest.verification.config.ts`.
 
-**Tier 2** — optional OpenClaw **gateway** in Docker with this plugin embedded (`npm pack` + `openclaw plugins install`), a mock OpenAI-compatible LLM, and an agent turn through the gateway:
+**Tier 2** — optional OpenClaw **gateway** in Docker with this plugin, mock OpenAI-compatible LLM, and an agent turn:
 
 ```bash
 make verify-openclaw-e2e
 ```
 
-Pin the gateway image with `OPENCLAW_TAG` (see `Makefile` default). Tier 2 details, ports, and the optional gateway benchmark are documented in [docs/VERIFICATION.md](docs/VERIFICATION.md). Human-review samples remain under `verification/samples/`.
+Set `OPENCLAW_TAG` to pin the gateway image (see `Makefile`). Details: [docs/VERIFICATION.md](docs/VERIFICATION.md). Human-review samples: `verification/samples/`.
 
-## Latency benchmark (Docker option)
+## Latency benchmark
 
-With Redact running in Docker:
-
-```bash
-docker run --rm -p 8080:8080 ghcr.io/censgate/redact:full
-```
-
-Run benchmark:
+With Redact running in Docker (e.g. `docker run --rm -p 8080:8080 ghcr.io/censgate/redact:full`):
 
 ```bash
 npm run benchmark
 ```
 
-Optional environment variables:
+Optional: `REDACT_API_ENDPOINT`, `BENCH_ITERATIONS`, `BENCH_WARMUP`, `BENCH_TEXT`.
 
-- `REDACT_API_ENDPOINT` (benchmark target)
-- `BENCH_ITERATIONS` (default: `100`)
-- `BENCH_WARMUP` (default: `10`)
-- `BENCH_TEXT` (custom test payload)
-
-### OpenClaw gateway benchmark (tier 2)
-
-When the tier-2 compose stack from `docker-compose.openclaw-e2e.yml` is running, you can sample host → gateway → mock latency:
+**Gateway benchmark (tier 2):** when the tier-2 stack from `docker-compose.openclaw-e2e.yml` is up:
 
 ```bash
 OPENCLAW_BENCHMARK=1 npm run benchmark:openclaw-gateway
 ```
 
+## Documentation
+
+- [Verification & E2E](docs/VERIFICATION.md) — ports, images, matrix tests
+- [Contributing](CONTRIBUTING.md) — PRs, dev setup, security contact
+- [Censgate Redact (engine)](https://github.com/censgate/redact) — API, Docker images, entity types, CLI
+- [Issues](https://github.com/censgate/openclaw-redact/issues) — bugs and feature requests
+
+## Contributing
+
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, `npm run lint` / `typecheck` / `test`, and the security reporting process.
+
 ## License
 
-Apache-2.0
+[Apache License 2.0](LICENSE).
+
+## Support
+
+- [GitHub Issues](https://github.com/censgate/openclaw-redact/issues) — bugs and feature requests
+- **Engine / API questions:** [censgate/redact](https://github.com/censgate/redact) and its docs
+- For security issues, follow [CONTRIBUTING.md](CONTRIBUTING.md) (do not use public issues for sensitive reports)
+
+---
+
+**[Star on GitHub](https://github.com/censgate/openclaw-redact)** if this plugin is useful to you.


### PR DESCRIPTION
Updates README to match censgate/redact branding (logo header, badges), simplify Quick Start to a zero-config local install path, and reorganize sections for open source release (requirements, config, docs links, support).