### PR TITLE
chore: add changeset for release automation

### DIFF
--- a/.changeset/release-automation.md
+++ b/.changeset/release-automation.md
@@ -1,0 +1,5 @@
+---
+"@censgate/openclaw-redact": patch
+---
+
+Automate versioning and npm releases with Changesets, a version-packages PR workflow, and automatic GitHub Releases that trigger the existing npm publish action.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -3,8 +3,9 @@ name: Changesets
 on:
   push:
     branches: [main]
-  pull_request:
 
+# Run only on main. On pull_request, changesets/action can hit GitHub
+# "base: invalid" when creating the version PR (merge ref / wrong base).
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:


### PR DESCRIPTION
Adds a pending Changeset so the Version packages PR workflow can run after merge. Patch bump documents the release automation shipped on main.