### PR TITLE
fix(ci): run npm publish after automated GitHub release

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,7 +1,9 @@
 name: Create GitHub Release
 
 # When the version on main changes (e.g. after the Changesets "Version packages" PR merges),
-# publish a GitHub Release so `publish.yml` can run `npm publish`.
+# create a GitHub Release. We then call the publish workflow here because releases created with
+# the default GITHUB_TOKEN do not trigger other workflows (including release: published).
+# See: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
 on:
   push:
     branches: [main]
@@ -12,6 +14,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.create.outputs.should_publish == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,17 +41,28 @@ jobs:
           echo "version=$NEW" >> "$GITHUB_OUTPUT"
 
       - name: Create release
+        id: create
         if: steps.bump.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION="${{ steps.bump.outputs.version }}"
           TAG="v${VERSION}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           gh release create "$TAG" \
             --target "${{ github.sha }}" \
             --title "$TAG" \
             --generate-notes
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    uses: ./.github/workflows/publish.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_call:
+    secrets:
+      NPM_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to npm
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
   workflow_call:


### PR DESCRIPTION
## Problem
GitHub does not start workflows when the default `GITHUB_TOKEN` causes the event (including `release: published`). So `gh release create` in **Create GitHub Release** created **v0.1.1** but **Publish to npm** never ran.

## Change
- Add `workflow_call` to **publish.yml** (same jobs as today).
- After creating a new release in **create-github-release.yml**, call that workflow with `NPM_TOKEN` when `should_publish` is true.
- Manual releases from the GitHub UI still trigger **publish.yml** via `release: published`.

## After merge
- **v0.1.1** is already on GitHub but not npm: publish once manually (`npm publish` from a maintainer machine with auth) or add a one-off workflow dispatch if you prefer.
- Future version bumps will publish automatically once this is on `main`.

Made with [Cursor](https://cursor.com)