### PR TITLE
chore: sync openclaw.plugin.json version on package bump

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "censgate-redact",
   "name": "Censgate OpenClaw Redact",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Privacy-preserving PII redaction for LLM-bound text via censgate/redact HTTP API.",
   "providers": ["censgate-mock"],
   "extensions": ["./dist/openclaw-plugin.js"],

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "lint:fix": "eslint src/ tests/ verification/ --fix",
     "typecheck": "tsc --noEmit",
     "changeset": "changeset",
-    "version-packages": "changeset version && npm install --package-lock-only --no-fund --no-audit",
-    "prepublishOnly": "npm run build"
+    "sync-plugin-version": "node scripts/sync-openclaw-plugin-version.mjs",
+    "version-packages": "changeset version && npm run sync-plugin-version && npm install --package-lock-only --no-fund --no-audit",
+    "prepublishOnly": "npm run sync-plugin-version && npm run build"
   },
   "keywords": [
     "openclaw",

--- a/scripts/sync-openclaw-plugin-version.mjs
+++ b/scripts/sync-openclaw-plugin-version.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const { version } = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const pluginPath = resolve(root, "openclaw.plugin.json");
+const text = readFileSync(pluginPath, "utf8");
+const re = /^(\s*"version"\s*:\s*")[^"]*(")/m;
+if (!re.test(text)) {
+  throw new Error('openclaw.plugin.json: missing top-level "version" field');
+}
+const next = text.replace(re, `$1${version}$2`);
+if (next !== text) {
+  writeFileSync(pluginPath, next, "utf8");
+}


### PR DESCRIPTION
Keeps `openclaw.plugin.json` `version` aligned with `package.json` when Changesets bumps the release and before `npm publish` (`prepublishOnly`).