### PR TITLE
chore(scripts): automate OpenClaw version metadata sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,26 @@
   "files": [
     "dist",
     "openclaw.plugin.json",
+    "scripts/postinstall.mjs",
+    "scripts/sync-openclaw-plugin-version.mjs",
     "LICENSE",
     "README.md"
   ],
   "openclaw": {
     "extensions": [
       "./dist/openclaw-plugin.js"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.4.24",
+      "minGatewayVersion": "2026.4.24"
+    },
+    "build": {
+      "openclawVersion": "2026.4.24",
+      "pluginSdkVersion": "2026.4.24"
+    }
   },
   "scripts": {
+    "postinstall": "node scripts/postinstall.mjs",
     "build": "tsc",
     "clean": "make clean",
     "test": "vitest run",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { existsSync, realpathSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const nm = `${sep}node_modules${sep}`;
+
+function inGitWorkTree(dir) {
+  let d = dir;
+  for (;;) {
+    if (existsSync(resolve(d, ".git"))) {
+      return true;
+    }
+    const p = dirname(d);
+    if (p === d) {
+      return false;
+    }
+    d = p;
+  }
+}
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+let realRoot;
+try {
+  realRoot = realpathSync(root);
+} catch {
+  process.exit(0);
+}
+if (realRoot.includes(nm)) {
+  process.exit(0);
+}
+if (!inGitWorkTree(realRoot)) {
+  process.exit(0);
+}
+
+const sync = resolve(root, "scripts", "sync-openclaw-plugin-version.mjs");
+const r = spawnSync(process.execPath, [sync], { stdio: "inherit" });
+process.exit(r.status ?? 1);

--- a/scripts/sync-openclaw-plugin-version.mjs
+++ b/scripts/sync-openclaw-plugin-version.mjs
@@ -3,14 +3,51 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const root = resolve(import.meta.dirname, "..");
-const { version } = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const packageJsonPath = resolve(root, "package.json");
+const openclawInstalledPath = resolve(root, "node_modules/openclaw/package.json");
 const pluginPath = resolve(root, "openclaw.plugin.json");
-const text = readFileSync(pluginPath, "utf8");
+
+const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const { version } = pkg;
+
+const pluginText = readFileSync(pluginPath, "utf8");
 const re = /^(\s*"version"\s*:\s*")[^"]*(")/m;
-if (!re.test(text)) {
+if (!re.test(pluginText)) {
   throw new Error('openclaw.plugin.json: missing top-level "version" field');
 }
-const next = text.replace(re, `$1${version}$2`);
-if (next !== text) {
-  writeFileSync(pluginPath, next, "utf8");
+const nextPlugin = pluginText.replace(re, `$1${version}$2`);
+if (nextPlugin !== pluginText) {
+  writeFileSync(pluginPath, nextPlugin, "utf8");
+}
+
+let openclawVersion;
+try {
+  openclawVersion = JSON.parse(readFileSync(openclawInstalledPath, "utf8")).version;
+} catch {
+  throw new Error(
+    "sync-openclaw-plugin-version: could not read openclaw from node_modules/openclaw/package.json. Run `npm install` first."
+  );
+}
+if (typeof openclawVersion !== "string" || !openclawVersion) {
+  throw new Error('node_modules/openclaw/package.json: missing or empty "version"');
+}
+
+if (!pkg.openclaw) {
+  throw new Error('package.json: missing top-level "openclaw" field');
+}
+if (!pkg.openclaw.compat) {
+  pkg.openclaw.compat = {};
+}
+if (!pkg.openclaw.build) {
+  pkg.openclaw.build = {};
+}
+pkg.openclaw.compat.pluginApi = `>=${openclawVersion}`;
+pkg.openclaw.compat.minGatewayVersion = openclawVersion;
+pkg.openclaw.build.openclawVersion = openclawVersion;
+pkg.openclaw.build.pluginSdkVersion = openclawVersion;
+
+const nextPackageJson = `${JSON.stringify(pkg, null, 2)}\n`;
+const currentPackageJson = readFileSync(packageJsonPath, "utf8");
+if (nextPackageJson !== currentPackageJson) {
+  writeFileSync(packageJsonPath, nextPackageJson, "utf8");
 }

--- a/scripts/sync-openclaw-plugin-version.mjs
+++ b/scripts/sync-openclaw-plugin-version.mjs
@@ -7,7 +7,8 @@ const packageJsonPath = resolve(root, "package.json");
 const openclawInstalledPath = resolve(root, "node_modules/openclaw/package.json");
 const pluginPath = resolve(root, "openclaw.plugin.json");
 
-const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const packageJsonText = readFileSync(packageJsonPath, "utf8");
+const pkg = JSON.parse(packageJsonText);
 const { version } = pkg;
 
 const pluginText = readFileSync(pluginPath, "utf8");
@@ -47,7 +48,6 @@ pkg.openclaw.build.openclawVersion = openclawVersion;
 pkg.openclaw.build.pluginSdkVersion = openclawVersion;
 
 const nextPackageJson = `${JSON.stringify(pkg, null, 2)}\n`;
-const currentPackageJson = readFileSync(packageJsonPath, "utf8");
-if (nextPackageJson !== currentPackageJson) {
+if (nextPackageJson !== packageJsonText) {
   writeFileSync(packageJsonPath, nextPackageJson, "utf8");
 }


### PR DESCRIPTION
## Summary
- Fills in required `openclaw.compat` and `openclaw.build` metadata in `package.json` (aligned with the installed `openclaw` version).
- Extends `sync-openclaw-plugin-version.mjs` to keep that metadata in sync with `node_modules/openclaw` (alongside the existing `openclaw.plugin.json` version).
- Adds `postinstall` via `scripts/postinstall.mjs`, which runs the sync only when developing from git (not when the package is installed from the registry under `node_modules`). The sync and postinstall scripts are listed in `package.json#files` so the published tarball can run the hook safely.

## Test plan
- [ ] `npm run sync-plugin-version` and `node scripts/postinstall.mjs` in this repo
- [ ] `npm pack --dry-run` includes the new script files

Made with [Cursor](https://cursor.com)