### PR TITLE
ci: add ClawHub publishing to release workflow

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -104,7 +104,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CLAWHUB_DISABLE_TELEMETRY: 1
+      HAS_CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN != '' }}
     steps:
+      - name: Check ClawHub token
+        run: |
+          if [ "$HAS_CLAWHUB_TOKEN" != "true" ]; then
+            echo "CLAWHUB_TOKEN not configured — skipping ClawHub publish"
+            exit 0
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Use Node.js 24
@@ -132,4 +142,4 @@ jobs:
           clawhub package publish . --dry-run
           clawhub package publish .
         env:
-          CLAWHUB_DISABLE_TELEMETRY: 1
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           if [ "$HAS_CLAWHUB_TOKEN" != "true" ]; then
             echo "CLAWHUB_TOKEN not configured — skipping ClawHub publish"
+            exit 0
           fi
 
       - uses: actions/checkout@v4

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -97,3 +97,39 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  clawhub-publish:
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Install clawhub CLI
+        run: npm install -g clawhub
+
+      - name: Login to ClawHub
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+
+      - name: Publish to ClawHub
+        run: |
+          clawhub package publish . --dry-run
+          clawhub package publish .
+        env:
+          CLAWHUB_DISABLE_TELEMETRY: 1

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -112,32 +112,38 @@ jobs:
         run: |
           if [ "$HAS_CLAWHUB_TOKEN" != "true" ]; then
             echo "CLAWHUB_TOKEN not configured — skipping ClawHub publish"
-            exit 0
           fi
 
       - uses: actions/checkout@v4
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         with:
           node-version: 24
           cache: npm
 
       - name: Install dependencies
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm ci
 
       - name: Build
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm run build
 
       - name: Install clawhub CLI
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm install -g clawhub
 
       - name: Login to ClawHub
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
 
       - name: Publish to ClawHub
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: |
           clawhub package publish . --dry-run
           clawhub package publish .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,6 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
-      CLAWHUB_TOKEN:
-        required: true
 
 permissions:
   contents: read
@@ -48,21 +46,3 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Install clawhub CLI
-        if: env.CLAWHUB_TOKEN != ''
-        run: npm install -g clawhub
-
-      - name: Login to ClawHub
-        if: env.CLAWHUB_TOKEN != ''
-        run: clawhub login --token $CLAWHUB_TOKEN --no-browser
-        env:
-          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-
-      - name: Publish to ClawHub
-        if: env.CLAWHUB_TOKEN != ''
-        run: |
-          clawhub package publish . --dry-run
-          clawhub package publish .
-        env:
-          CLAWHUB_DISABLE_TELEMETRY: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish
 
 on:
   workflow_dispatch:
@@ -7,6 +7,8 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
+        required: true
+      CLAWHUB_TOKEN:
         required: true
 
 permissions:
@@ -42,7 +44,25 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish
+      - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install clawhub CLI
+        if: env.CLAWHUB_TOKEN != ''
+        run: npm install -g clawhub
+
+      - name: Login to ClawHub
+        if: env.CLAWHUB_TOKEN != ''
+        run: clawhub login --token $CLAWHUB_TOKEN --no-browser
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+
+      - name: Publish to ClawHub
+        if: env.CLAWHUB_TOKEN != ''
+        run: |
+          clawhub package publish . --dry-run
+          clawhub package publish .
+        env:
+          CLAWHUB_DISABLE_TELEMETRY: 1


### PR DESCRIPTION
## Summary

Extend the existing publish workflow to also publish the plugin to ClawHub on releases.

## Changes

- Renamed workflow from "Publish to npm" → "Publish" (encapsulates both)
- Added `CLAWHUB_TOKEN` secret requirement to `workflow_call`
- Added ClawHub CLI installation step (conditional on `CLAWHUB_TOKEN`)
- Added ClawHub login step with token
- Added ClawHub package publish step (with `--dry-run` first to catch issues)

## How it works

The ClawHub publish steps only run when `CLAWHUB_TOKEN` is provided, so this is safe to merge before the secret is configured.

**Required setup after merge:**
1. Add `CLAWHUB_TOKEN` secret to the repository settings
2. Next release will automatically publish to both npm and ClawHub

## Testing

- Verified workflow syntax is valid
- Steps are conditional on environment variable presence

---
/cc @censgate-mark