### PR TITLE
Security: bump fast-uri and fast-xml-builder for CVE-2026-6322 and CVE-2026-44665

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Bump `@anthropic-ai/sdk` to `^0.91.1` via npm override to address CVE-2026-41686 (Insecure Default File Permissions in Local Filesystem Memory Tool). This is a devDependency with no runtime impact.
+- Add npm overrides for `fast-uri` (^3.1.2) to address GHSA-v39h-62p7-jpjc / CVE-2026-6322 (host confusion via percent-encoded authority delimiters).
+- Add npm overrides for `fast-xml-builder` (^1.1.7) to address GHSA-xq4p-q4h5-j25r / CVE-2026-44665 (attribute values with unwanted quotes bypassing validation).
+
+Both are transitive devDependencies with no production code impact.
 
 ## 0.1.4 - 2026-04-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6776,9 +6776,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6803,9 +6803,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -6815,7 +6815,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -11032,6 +11033,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
   "overrides": {
     "axios": "^1.15.0",
     "fast-xml-parser": "^5.7.0",
+    "fast-xml-builder": "^1.1.7",
+    "fast-uri": "^3.1.2",
     "postcss": "^8.5.10",
     "protobufjs": "^7.5.5",
     "tar": "^7.5.11",


### PR DESCRIPTION
## Summary

Addresses HIGH severity Dependabot alerts:

### CVE-2026-6322 (GHSA-v39h-62p7-jpjc) - fast-uri
- **Severity:** HIGH (CVSS 7.5)
- **Impact:** Host confusion via percent-encoded authority delimiters  
- **Fix:** Override fast-uri to ^3.1.2

### CVE-2026-44665 (GHSA-xq4p-q4h5-j25r) - fast-xml-builder  
- **Severity:** HIGH
- **Impact:** Attribute values with unwanted quotes bypassing validation
- **Fix:** Override fast-xml-builder to ^1.1.7

### Analysis
- Both are **transitive devDependencies** (via ajv and related packages)
- No production runtime code paths affected
- EPSS scores are low (0.00029-0.00030) indicating minimal wild exploitation
- Manual verification: no direct imports of these packages found in src/

### Changes
- Added overrides to package.json
- Updated package-lock.json via npm install --package-lock-only
- Added CHANGELOG entries to [Unreleased]

---
*Automated security review completed: 2026-05-09*