### PR TITLE
Security: bump hono and ip-address for MEDIUM/LOW severity CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add npm overrides for `fast-xml-builder` (^1.1.7) to address GHSA-xq4p-q4h5-j25r / CVE-2026-44665 (attribute values with unwanted quotes bypassing validation).
 
 Both are transitive devDependencies with no production code impact.
+- Add npm overrides for `hono` (^4.12.18) to address CVE-2026-44458, CVE-2026-44457, CVE-2026-44455, CVE-2026-44459 (CSS injection, cache leakage, HTML injection, JWT validation).
+- Add npm overrides for `ip-address` (^10.1.2) to address CVE-2026-42338 (XSS via Address6 HTML methods).
+
+All are transitive devDependencies with no production code impact.
 
 ## 0.1.4 - 2026-04-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7456,9 +7456,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7627,9 +7627,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -82,11 +82,16 @@
     "fast-xml-parser": "^5.7.0",
     "fast-xml-builder": "^1.1.7",
     "fast-uri": "^3.1.2",
+    "hono": "^4.12.18",
+    "ip-address": "^10.1.2",
     "postcss": "^8.5.10",
     "protobufjs": "^7.5.5",
     "tar": "^7.5.11",
     "uuid": "^14.0.0",
-    "@anthropic-ai/sdk": "^0.91.1"
+    "@anthropic-ai/sdk": "^0.91.1",
+    "@mariozechner/pi-agent-core": {
+      "hono": "^4.12.18"
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Addresses MEDIUM/LOW severity Dependabot alerts (companion to PR #22 which covered HIGH severity CVEs).

### MEDIUM Severity

#### CVE-2026-44458 (CSS Declaration Injection) - hono
- **Severity:** MEDIUM
- **Impact:** CSS can be injected via style object values in JSX SSR
- **Fix:** Override hono ^4.12.18

#### CVE-2026-44457 (Cache Middleware leakage) - hono  
- **Severity:** MEDIUM
- **Impact:** Vary: Authorization/Cookie ignored, leading to cross-user cache leakage
- **Fix:** Override hono ^4.12.18

#### CVE-2026-44455 (HTML Injection via JSX) - hono
- **Severity:** MEDIUM
- **Impact:** Unvalidated JSX tag names may allow HTML injection
- **Fix:** Override hono ^4.12.18

#### CVE-2026-42338 (XSS via Address6) - ip-address
- **Severity:** MEDIUM
- **Impact:** XSS in Address6 HTML-emitting methods
- **Fix:** Override ip-address ^10.1.2

### LOW Severity

#### CVE-2026-44459 (JWT validation) - hono
- **Severity:** LOW
- **Impact:** Improper validation of NumericDate claims in JWT verify()
- **Fix:** Override hono ^4.12.18 (already covered above)

### Analysis
- All **transitive devDependencies** via @mariozechner/pi-agent-core
- No production runtime code paths affected
- EPSS scores unavailable for these CVEs (likely newly disclosed)
- MEDIUM severity warrants remediation even without active exploitation

### Changes
- Added overrides to package.json for hono and ip-address
- Updated package-lock.json via npm install --package-lock-only
- Added CHANGELOG entries to [Unreleased]

---
*Automated security review completed: 2026-05-09*