### PR TITLE
chore: changeset for security / Dependabot patch release

### DIFF
--- a/.changeset/security-cve-dependabot.md
+++ b/.changeset/security-cve-dependabot.md
@@ -1,0 +1,5 @@
+---
+"@censgate/openclaw-redact": patch
+---
+
+Security fixes for medium CVEs via dependabot updates


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **patch** Changesets entry for `@censgate/openclaw-redact` so merging this PR (together with any Dependabot dependency bumps on `main`) triggers the usual release pipeline.

After this lands on `main`, the Changesets workflow should open a **Version packages** PR. Merging that bumps the package version, creates the GitHub release, publishes to npm, and runs ClawHub publish when `CLAWHUB_TOKEN` is configured.

## Changeset summary

Security fixes for medium CVEs via dependabot updates
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e90b479a-421b-427f-afd6-d413da9ea849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e90b479a-421b-427f-afd6-d413da9ea849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

