### PR TITLE
fix(ci): Fix ClawHub publish step - use ClawPack format

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -133,6 +133,10 @@ jobs:
         if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm run build
 
+      - name: Build ClawPack
+        if: env.HAS_CLAWHUB_TOKEN == 'true'
+        run: npm pack --pack-destination ./dist/
+
       - name: Install clawhub CLI
         if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: npm install -g clawhub
@@ -146,7 +150,7 @@ jobs:
       - name: Publish to ClawHub
         if: env.HAS_CLAWHUB_TOKEN == 'true'
         run: |
-          clawhub package publish . --dry-run
-          clawhub package publish .
+          clawhub package publish ./dist/*.tgz --family code-plugin --dry-run
+          clawhub package publish ./dist/*.tgz --family code-plugin
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the ClawHub publish step which was failing due to the legacy ZIP format. ClawHub now requires **ClawPack** (npm-pack tarball).

## Changes

### File: `.github/workflows/create-github-release.yml`

In the `clawhub-publish` job:

1. **Added Build ClawPack step** (before "Install clawhub CLI"):
   ```yaml
   - name: Build ClawPack
     if: env.HAS_CLAWHUB_TOKEN == 'true'
     run: npm pack --pack-destination ./dist/
   ```

2. **Updated Publish step** from:
   ```yaml
   clawhub package publish .
   ```
   To:
   ```yaml
   clawhub package publish ./dist/*.tgz --family code-plugin
   ```

## Verification

- npm publish already works (not affected)
- `package.json` already has required `openclaw` metadata

## Related

- Failed run: https://github.com/censgate/openclaw-redact/actions/runs/25606132931/job/75168245256
- Fixes CEN-56