### PR TITLE
chore: changeset for security / Dependabot patch release

### DIFF
--- a/.changeset/security-dependabot-2026-05.md
+++ b/.changeset/security-dependabot-2026-05.md
@@ -1,0 +1,5 @@
+---
+"@censgate/openclaw-redact": patch
+---
+
+Security: regenerate lockfile and resolve npm audit advisories (transitive devDependencies only).


### PR DESCRIPTION
Adds a **patch** Changesets entry for `@censgate/openclaw-redact` so merging this PR (together with the security dependency bumps already on `main`) triggers the usual release pipeline.

After this lands on `main`, the Changesets workflow should open a **Version packages** PR. Merging that bumps the package version to 0.1.7, creates the GitHub release, publishes to npm, and runs ClawHub publish when `CLAWHUB_TOKEN` is configured.

Made with [Cursor](https://cursor.com)