### PR TITLE
fix(deps): bump qs to ^6.15.2 (CVE-2026-8723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Security
 
+- Security: bump `qs` to ^6.15.2 (CVE-2026-8723) via npm override. Transitive devDependency (body-parser); not used in published runtime (`uuid`, `zod` only). EPSS 0.04%, CVSS 5.3.
 - Regenerate `package-lock.json` to apply existing npm overrides for transitive CVE fixes (fast-uri, fast-xml-builder, hono, ip-address, protobufjs, basic-ftp, @anthropic-ai/sdk). All are transitive devDependencies with no production code impact.
 - Security: bump protobufjs to ^7.5.8 via npm override to address CVE-2026-44293, CVE-2026-44291, CVE-2026-44290, CVE-2026-44294, CVE-2026-44292, CVE-2026-44288 (code injection, DoS, prototype pollution). This is a transitive devDependency via @google/genai with no production code impact.
 - Security: refresh `package-lock.json` to pull `basic-ftp` 5.3.1 (GHSA-rpmf-866q-6p89), `brace-expansion` 5.0.6 (GHSA-jxxr-4gwj-5jf2), and `ws` 8.20.1 (GHSA-58qx-3vcg-4xpx). These remain transitive **devDependency** paths (OpenClaw gateway / agent stacks used in tests and local development); the published package runtime graph is still `uuid` and `zod` only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9447,9 +9447,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "zod": "^4.3.6"
   },
   "overrides": {
+    "qs": "^6.15.2",
     "axios": "^1.15.0",
     "fast-xml-parser": "^5.7.0",
     "fast-xml-builder": "^1.1.7",


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#47](https://github.com/censgate/openclaw-redact/security/dependabot/47) for **CVE-2026-8723** (`qs` DoS via `stringify` with `arrayFormat: 'comma'` + `encodeValuesOnly`).

## Risk assessment

| Signal | Value |
|--------|-------|
| CVSS | 5.3 (medium) |
| EPSS | 0.04% (< 0.1 threshold) |
| Scope | `development` (transitive via `body-parser` → `express` → `openclaw` devDependency) |
| Production runtime | **Not reachable** — published package depends only on `uuid` and `zod`; no `qs` import in `src/` |

## Fix

- npm override: `"qs": "^6.15.2"`
- `package-lock.json` updated (`qs` 6.15.1 → 6.15.2)

## Verification

- [x] `npm test` (25 tests) locally
- [ ] CI green on this PR

## Changelog

Security: bump `qs` to ^6.15.2 (CVE-2026-8723)