### PR TITLE
security(deps): bump hono to ^4.12.21 (CVE-2026-47673–47676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Security
 
+- Security: bump `hono` to ^4.12.21 (CVE-2026-47673, CVE-2026-47674, CVE-2026-47675, CVE-2026-47676) via npm override. Transitive devDependency via OpenClaw/MCP SDK; not used in published runtime (`uuid`, `zod` only). EPSS < 0.13%, CVSS 4.3–5.3.
 - Security: bump `qs` to ^6.15.2 (CVE-2026-8723) via npm override. Transitive devDependency (body-parser); not used in published runtime (`uuid`, `zod` only). EPSS 0.04%, CVSS 5.3.
 - Regenerate `package-lock.json` to apply existing npm overrides for transitive CVE fixes (fast-uri, fast-xml-builder, hono, ip-address, protobufjs, basic-ftp, @anthropic-ai/sdk). All are transitive devDependencies with no production code impact.
 - Security: bump protobufjs to ^7.5.8 via npm override to address CVE-2026-44293, CVE-2026-44291, CVE-2026-44290, CVE-2026-44294, CVE-2026-44292, CVE-2026-44288 (code injection, DoS, prototype pollution). This is a transitive devDependency via @google/genai with no production code impact.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7445,9 +7445,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "fast-xml-parser": "^5.7.0",
     "fast-xml-builder": "^1.1.7",
     "fast-uri": "^3.1.2",
-    "hono": "^4.12.18",
+    "hono": "^4.12.21",
     "ip-address": "^10.1.2",
     "postcss": "^8.5.10",
     "protobufjs": "^7.5.8",
@@ -92,7 +92,7 @@
     "uuid": "^14.0.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@mariozechner/pi-agent-core": {
-      "hono": "^4.12.18"
+      "hono": "^4.12.21"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

Addresses Dependabot alerts [#51](https://github.com/censgate/openclaw-redact/security/dependabot/51)–[#54](https://github.com/censgate/openclaw-redact/security/dependabot/54) for four medium-severity **hono** CVEs (patched in 4.12.21).

## Risk assessment

| Field | Value |
|-------|-------|
| **CVSS** | 4.3–5.3 (Medium) |
| **EPSS** | 0.037%–0.125% (all below 0.1% threshold) |
| **Scope** | development — transitive via OpenClaw / MCP SDK |
| **Reachable** | No in `src/` (no hono imports); published runtime is `uuid` + `zod` only |

## Changes

- Bump `hono` npm override from `^4.12.18` to `^4.12.21` (lockfile resolves to 4.12.23)
- Regenerate `package-lock.json`
- CHANGELOG security entry

## Verification

- `npm test` — 25 passed
