### PR TITLE
security(deps): bump protobufjs, tar, and ws overrides (GHSA high)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Security
 
+- Security: bump `protobufjs` to ^7.6.3, `tar` to ^7.5.16, and `ws` to ^8.21.0 via npm overrides (GHSA-f38q-mgvj-vph7, GHSA-wcpc-wj8m-hjx6, GHSA-vmf3-w455-68vh, GHSA-96hv-2xvq-fx4p). Transitive **devDependency** paths via OpenClaw / GenAI test stacks; published runtime remains `uuid` and `zod` only.
 - Security: bump `vitest` to ^4.1.0 (CVE-2026-47429 / GHSA-5xrq-8626-4rwp). CVSS 9.8; EPSS not yet published. **devDependency** only (`vitest run` in CI; Vitest UI/API not exposed). Reachable in tests: yes; production runtime: no.
 - Security: bump `hono` to ^4.12.21 (CVE-2026-47673–47676). CVSS 4.3–5.3; EPSS 0.037%–0.125%. Transitive **devDependency** via OpenClaw/MCP SDK overrides; not imported in `src/`.
 - Security: bump `qs` to ^6.15.2 (CVE-2026-8723) via npm override. Transitive devDependency (body-parser); not used in published runtime (`uuid`, `zod` only). EPSS 0.04%, CVSS 5.3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3298,34 +3298,26 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -8868,9 +8860,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -8878,15 +8870,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10082,9 +10073,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10707,9 +10698,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -87,8 +87,9 @@
     "hono": "^4.12.21",
     "ip-address": "^10.1.2",
     "postcss": "^8.5.10",
-    "protobufjs": "^7.5.8",
-    "tar": "^7.5.11",
+    "protobufjs": "^7.6.3",
+    "tar": "^7.5.16",
+    "ws": "^8.21.0",
     "uuid": "^14.0.0",
     "@anthropic-ai/sdk": "^0.91.1",
     "@mariozechner/pi-agent-core": {


### PR DESCRIPTION
## Summary

Daily Dependabot security review remediation for high-severity npm audit findings in transitive devDependencies.

### Changes

- Bump `protobufjs` override to `^7.6.3` (GHSA-f38q-mgvj-vph7, GHSA-wcpc-wj8m-hjx6)
- Bump `tar` override to `^7.5.16` (GHSA-vmf3-w455-68vh)
- Add `ws` override `^8.21.0` (GHSA-96hv-2xvq-fx4p)

### Risk assessment

| Advisory | Severity | Scope | Reachable |
|---|---|---|---|
| GHSA-f38q-mgvj-vph7 / GHSA-wcpc-wj8m-hjx6 | High | devDependency (GenAI/OpenClaw test stack) | No production path |
| GHSA-vmf3-w455-68vh | Moderate | devDependency (openclaw) | No production path |
| GHSA-96hv-2xvq-fx4p | High | devDependency (ws via GenAI/OpenAI clients) | No production path |

Published package runtime dependencies remain `uuid` and `zod` only.

### Verification

- `npm audit`: 0 high/critical (15 moderate dev-only remain: js-yaml/@changesets, markdown-it/openclaw)
- `npm test`: 25/25 passed

Part of daily Dependabot security review 2026-06-16.